### PR TITLE
Emotion: Compat with React 19 types

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "@testing-library/react": "13.0.0-alpha.5",
     "@types/jest": "^27.0.3",
     "@types/node": "^12.20.37",
-    "@types/react": "^18.0.9",
+    "@types/react": "npm:types-react@19.0.0-alpha.2",
     "babel-check-duplicated-nodes": "^1.0.0",
     "babel-eslint": "^10.1.0",
     "babel-flow-types": "^1.2.3",
@@ -245,6 +245,8 @@
   },
   "packageManager": "yarn@3.2.3",
   "resolutions": {
+    "@types/react": "npm:types-react@19.0.0-alpha.2",
+    "@types/react-dom": "npm:types-react-dom@19.0.0-alpha.2",
     "jest-snapshot@27.4.5": "patch:jest-snapshot@npm:27.4.5#.yarn/patches/jest-snapshot-npm-27.4.5-6ace6bf68e.patch"
   }
 }

--- a/packages/react/types/helper.d.ts
+++ b/packages/react/types/helper.d.ts
@@ -1,5 +1,7 @@
 import * as React from 'react'
 
+import type { JSX } from "react";
+
 /**
  * @desc Utility type for getting props type of React component.
  * It takes `defaultProps` into an account - making props with defaults optional.

--- a/packages/react/types/jsx-namespace.d.ts
+++ b/packages/react/types/jsx-namespace.d.ts
@@ -1,4 +1,4 @@
-import 'react'
+import { type JSX } from 'react';
 import { Interpolation } from '@emotion/serialize'
 import { Theme } from '@emotion/react'
 

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -1,3 +1,4 @@
+import type * as PropTypes from "prop-types";
 /** @jsx jsx */
 import * as React from 'react'
 import {
@@ -20,7 +21,7 @@ declare module '@emotion/react' {
   }
 }
 
-;<Global styles={[]} />
+<Global styles={[]} />
 ;<Global styles={theme => [theme.primaryColor]} />
 
 declare const getRandomColor: () => string
@@ -187,8 +188,8 @@ const anim1 = keyframes`
       any,
       any
     > | null
-    propTypes?: React.WeakValidationMap<P> | undefined
-    contextTypes?: React.ValidationMap<any> | undefined
+    propTypes?: PropTypes.WeakValidationMap<P> | undefined
+    contextTypes?: PropTypes.ValidationMap<any> | undefined
     defaultProps?: Partial<P> | undefined
     displayName?: string | undefined
   }

--- a/packages/styled/types/base.d.ts
+++ b/packages/styled/types/base.d.ts
@@ -5,6 +5,8 @@ import * as React from 'react'
 import { ComponentSelector, Interpolation } from '@emotion/serialize'
 import { PropsOf, Theme } from '@emotion/react'
 
+import type { JSX } from "react";
+
 export {
   ArrayInterpolation,
   CSSObject,

--- a/packages/styled/types/index.d.ts
+++ b/packages/styled/types/index.d.ts
@@ -4,6 +4,8 @@
 import { Theme } from '@emotion/react'
 import { CreateStyled as BaseCreateStyled, CreateStyledComponent } from './base'
 
+import type { JSX } from "react";
+
 export {
   ArrayInterpolation,
   ComponentSelector,

--- a/packages/styled/types/tests.tsx
+++ b/packages/styled/types/tests.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import styled, { StyledOptions, FilteringStyledOptions } from '@emotion/styled'
 
+import type { JSX } from "react";
+
 // This file uses the same Theme declaration from tests-base.tsx
 
 {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5766,13 +5766,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*":
-  version: 15.7.1
-  resolution: "@types/prop-types@npm:15.7.1"
-  checksum: f8b33d7d15a70d0b709bcf5f281c7647ca8aaeaf377431725b4fda4949f2845476652d355eec0cde2a62ba3f7a5fb3194788aebaecc2048eb28db201121c2310
-  languageName: node
-  linkType: hard
-
 "@types/q@npm:^1.5.1":
   version: 1.5.2
   resolution: "@types/q@npm:1.5.2"
@@ -5789,14 +5782,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:>=16, @types/react@npm:^18.0.9":
-  version: 18.0.14
-  resolution: "@types/react@npm:18.0.14"
+"@types/react@npm:types-react@19.0.0-alpha.2":
+  version: 19.0.0-alpha.2
+  resolution: "types-react@npm:19.0.0-alpha.2"
   dependencies:
-    "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: 608eb57a383eedc54c79949673e5e8314f6b0c61542bff58721c8c47a18c23e2832e77c656050c2c2c004b62cf25582136c7c56fe1b6263a285c065fae31dbcf
+  checksum: 0de04b12324b9cd08d0bb9489ad244cfc2f9f47f9a04317c5d4bc7f69ef8688d3672370881471729239df45700c26d910d1e9fb9e6d76fabf193063cd08e2c8a
   languageName: node
   linkType: hard
 
@@ -11558,7 +11550,7 @@ __metadata:
     "@testing-library/react": 13.0.0-alpha.5
     "@types/jest": ^27.0.3
     "@types/node": ^12.20.37
-    "@types/react": ^18.0.9
+    "@types/react": "npm:types-react@19.0.0-alpha.2"
     babel-check-duplicated-nodes: ^1.0.0
     babel-eslint: ^10.1.0
     babel-flow-types: ^1.2.3


### PR DESCRIPTION
Closes https://github.com/eps1lon/DefinitelyTyped/issues/29

Unclear if there are any remaining issues since the repo is a) at least 70 versions behind latest React 18 types and b) the tooling does not support latest types from DefinitelyTyped since it still tests with TypeScript 3.9 which has long been out of maintenance ([current lowest supported TypeScript version in the types ecosystem is 4.7](https://github.com/definitelyTyped/DefinitelyTyped/#support-window))